### PR TITLE
fix(LH-71564): Fix filter by version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,12 +13,7 @@ locals {
 data "aws_ami" "sdc" {
   filter {
     name   = "name"
-    values = ["cdo-connector*"]
-  }
-
-  filter {
-    name   = "tag:version"
-    values = [local.ami_version]
+    values = ["cdo-connector-${ami_version}-*"]
   }
 
   filter {

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 locals {
-  ami_version = "v0.0.1"  # see https://github.com/cisco-lockhart/sec_cookbook
+  ami_version = "v0.0.5"  # see https://github.com/cisco-lockhart/sec_cookbook
 }
 
 data "aws_ami" "sdc" {


### PR DESCRIPTION
This is the PR associated with the change in the way to filter the AMI image
See https://github.com/cisco-lockhart/sec_cookbook/pull/8 for more information