### PR TITLE
fix: allow ssh egress to 0.0.0.0/0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,14 @@ data "aws_ami" "sdc" {
 resource "aws_security_group" "sdc" {
   vpc_id      = var.vpc_id
   name        = "${var.env}-${var.instance_name}-sdc-sg"
-  description = "Security Group that allows all egress to the internet on TCP port 443"
+  description = "Security Group that allows all egress to the internet on TCP port 22 and 443"
+
+  egress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   egress {
     from_port   = 443


### PR DESCRIPTION
### Description

Allow SSH outbound traffic so the SDC can onboard iOS devices