### PR TITLE
chore(lh-73034): bump up version of cdo-connector

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 locals {
-  ami_version = "v0.0.5"  # see https://github.com/cisco-lockhart/sec_cookbook
+  ami_version = "v0.1.1"  # see https://github.com/cisco-lockhart/sec_cookbook
 }
 
 data "aws_ami" "sdc" {


### PR DESCRIPTION
v0.1.1 is a version that is also released to ap-southeast-2 (Australia)
