### PR TITLE
fix(LH-83364): upgrade the version of the cdo-connector AMI used in terraform-aws-cdo-sdc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 locals {
-  ami_version = "0.1.2-SNAPSHOT"  # see https://github.com/cisco-lockhart/sec_cookbook
+  ami_version = "a1dc5c0f78915135f94f3ca03cce172f34c96bf5"  # see https://jenkins2.dev.lockhart.io/job/Bakery/job/cdo-connector-ami/
 }
 
 data "aws_ami" "sdc" {

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 locals {
-  ami_version = "v0.1.1"  # see https://github.com/cisco-lockhart/sec_cookbook
+  ami_version = "0.1.2-SNAPSHOT"  # see https://github.com/cisco-lockhart/sec_cookbook
 }
 
 data "aws_ami" "sdc" {

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ data "aws_ami" "sdc" {
     values = ["x86_64"]
   }
 
-  owners = ["692314432491"]
+  owners = ["005087805285"]
 
   most_recent = true
 }


### PR DESCRIPTION
Upgrade the cdo-connector AMI to use a new version of the cdo-connector AMI built on Cisco-hardened Ubuntu.